### PR TITLE
Problem: Tntnet crashes if DB stops responding.

### DIFF
--- a/tntdb/src/mysql/connection.cpp
+++ b/tntdb/src/mysql/connection.cpp
@@ -71,6 +71,9 @@ namespace tntdb
         throw std::runtime_error("cannot initalize mysql");
       initialized = true;
 
+      unsigned int timeout = 300;
+      mysql_options(&mysql, MYSQL_OPT_READ_TIMEOUT, &timeout);
+
       if (::mysql_options(&mysql, MYSQL_READ_DEFAULT_GROUP, app && app[0] ? app : "tntdb") != 0)
         throw MysqlError("mysql_options", &mysql);
 


### PR DESCRIPTION
Solution: Set connect timeout lower then TCP/IP Close_Wait_Timeout (10 minutes).

Signed-off-by: Jana Rapava <janarapava@eaton.com>